### PR TITLE
Use Kramdown instead of RDiscount

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'kramdown'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    kramdown (1.17.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  kramdown
+
+BUNDLED WITH
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ At the top of each file is some attributes — lines that start with a `@` sign.
 
 Files are treated according to their suffixes: `.html` means not to process the text; `.markdown` means to use the Markdown renderer.
 
-(Wildcat requires the RDiscount gem for Markdown rendering.)
+(Wildcat requires the Kramdown gem for Markdown rendering.)
 
 ## Macros
 
@@ -54,4 +54,11 @@ TBD
 
 ## How to run locally
 
-TBD
+Install gem dependencies from `Gemfile`:
+
+```
+gem install bundler
+bundle install
+```
+
+**TBD**

--- a/utilities/wildcat_file.rb
+++ b/utilities/wildcat_file.rb
@@ -1,7 +1,7 @@
 # Contains the attributes, text, and text type of a file.
 # Could be a page, post, or settings file.
 
-require 'rdiscount'
+require 'kramdown'
 require_relative 'file_parser'
 require_relative '../wildcat_constants'
 
@@ -43,6 +43,15 @@ class WildcatFile
   end
 
   def render_text
-     @text_type == TEXT_TYPE_MARKDOWN ? RDiscount.new(@text).to_html : @text
+    if @text_type == TEXT_TYPE_MARKDOWN
+      Kramdown::Document.new(
+      MarkdownMedia.parse(@text),
+      input: :kramdown,
+      remove_block_html_tags: false,
+      transliterated_header_ids: true
+      ).to_html
+    else
+      @text
+    end
   end
 end

--- a/utilities/wildcat_file.rb
+++ b/utilities/wildcat_file.rb
@@ -45,7 +45,7 @@ class WildcatFile
   def render_text
     if @text_type == TEXT_TYPE_MARKDOWN
       Kramdown::Document.new(
-      MarkdownMedia.parse(@text),
+      @text,
       input: :kramdown,
       remove_block_html_tags: false,
       transliterated_header_ids: true

--- a/utilities/wildcat_file.rb
+++ b/utilities/wildcat_file.rb
@@ -45,10 +45,10 @@ class WildcatFile
   def render_text
     if @text_type == TEXT_TYPE_MARKDOWN
       Kramdown::Document.new(
-      @text,
-      input: :kramdown,
-      remove_block_html_tags: false,
-      transliterated_header_ids: true
+        @text,
+        input: :kramdown,
+        remove_block_html_tags: false,
+        transliterated_header_ids: true
       ).to_html
     else
       @text


### PR DESCRIPTION
Added `Gemfile` to add `kramdown` as a dependency.

***

Make sure you have Bundler installed:

`bundle -v`

If you don't, install it.

`gem install bundler`

Because you're using system Ruby, you might need to `sudo` that.

`sudo gem install bundler`

***

When you have Bundler installed, `bundle` your gem dependencies from your `Gemfile`.

`bundle install`

***

After that, your usage _should_ be the same as it ever was. Same as it ever was.

***

Lemme know if that Just Works™ for you on Mojave + System Ruby. If not, I have a very simple approach to using non-system Ruby that I can add to the project for you.