### PR TITLE
Add stringex to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'kramdown'
+gem 'stringex'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     kramdown (1.17.0)
+    stringex (2.8.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   kramdown
+  stringex
 
 BUNDLED WITH
    1.16.2


### PR DESCRIPTION
Stringex is used by Kramdown in Markdown parsing for adding IDs to headings