### PR TITLE
Add gemspec to allow use as a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'kramdown'
-gem 'stringex'
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,23 @@
+PATH
+  remote: .
+  specs:
+    wildcat (0.0.1)
+      kramdown
+      stringex
+
 GEM
   remote: https://rubygems.org/
   specs:
-    kramdown (2.3.1)
+    kramdown (2.4.0)
       rexml
     rexml (3.2.5)
-    stringex (2.8.4)
+    stringex (2.8.5)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
-  kramdown
-  stringex
+  wildcat!
 
 BUNDLED WITH
-   1.16.2
+   2.3.18

--- a/utilities/file_parser.rb
+++ b/utilities/file_parser.rb
@@ -3,7 +3,7 @@
 #
 # Works for posts, pages, and wildcat_settings.
 
-require 'Time'
+require 'time'
 require 'fileutils'
 
 module FileParser

--- a/wildcat.gemspec
+++ b/wildcat.gemspec
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |s|
+  s.name          = "wildcat"
+  s.summary       = "CMS and blogging system that generates static pages"
+  s.version       = "0.0.1"
+  s.author        = "Brent Simmons"
+  s.homepage      = "https://github.com/brentsimmons/wildcat"
+  s.files         = `git ls-files`.strip.split(/\s+/).reject {|f| f.match(%r{^test/}) }
+  s.require_paths = ["."]
+
+  s.add_dependency "kramdown"
+  s.add_dependency "stringex"
+end


### PR DESCRIPTION
The README is clear that you are not looking for pull requests. The reason I am disregarding this notice is merely to make the experience of building the NetNewsWire help pages more pleasant. This PR is necessary for Ranchero-Software/NetNewsWireHelp#23.